### PR TITLE
カラーテーマの設定

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -409,7 +409,7 @@
       padding: 5px 20px;
       width: 100%;
       height: 50px;
-      background-color: #ffda6f;
+      background-color: var(--v-main-base);
       z-index: 2;
 
       .playing-track-info {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <v-app-bar
       app
-      color="#ffda6f"
+      color="main"
       height="50"
       elevation="0"
       class="header"
@@ -41,7 +41,7 @@
         <div class="right">
           <div id="search">
             <v-icon
-              color="rgb(249, 102, 102)"
+              color="accent"
               size="30"
               class="icon-search"
             >mdi-magnify</v-icon>
@@ -168,7 +168,7 @@
 
 <style lang="scss">
   .v-main__wrap {
-    background-color: #f6f6f6;
+    background-color: var(--v-background1-base);
     overflow: hidden;
   }
 
@@ -200,7 +200,7 @@
   .main-container {
     height: calc(100vh - 50px);
     max-width: 1390px;
-    background-color: #fffbe8;
+    background-color: var(--v-background2-base);
     font-size: 97%;
     font-family: 'Noto Sans JP', sans-serif;;
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@
             >mdi-magnify</v-icon>
             <v-text-field
               v-model="query"
-              color="#e55555"
+              color="accent"
               hint="キーワードで検索: 「歌ってみた コラボ」「歌枠 音源あり」..."
             ></v-text-field>
             <v-btn

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -69,8 +69,8 @@
           @click="seekEnd"
           min="0"
           :max="seekbarMax"
-          color="#ff0000"
-          track-color="rgba(255, 0, 0, 0.2)"
+          color="accent"
+          track-color="accent lighten-1"
           class="seekbar"
         ></v-slider>
 

--- a/src/components/TrackList.vue
+++ b/src/components/TrackList.vue
@@ -212,7 +212,8 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: rgba(196, 255, 156, 0.2);
+        opacity: 0.2;
+        background-color: var(--v-sub-base);
         pointer-events: none;
       }
     }

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -3,4 +3,20 @@ import Vuetify from 'vuetify/lib';
 
 Vue.use(Vuetify);
 
-export default new Vuetify();
+export default new Vuetify({
+  theme: {
+    themes: {
+      light: {
+        main: '#ffda6f',
+        sub: '#c4ff9c',
+        accent: {
+          base: '#f96666',
+          lighten1: '#ffd1d1',
+        },
+        background1: '#f6f6f6',
+        background2: '#fffbe8',
+      },
+    },
+    options: { customProperties: true },
+  }
+});


### PR DESCRIPTION
[Vuetifyのテーマ設定機能](https://vuetifyjs.com/en/features/theme/)を使って色を管理する．

https://github.com/yay4ya/akikunouta/blob/510d1e20eb0d84fbe8d7f012dcbf37b0f3fcb8a5/src/plugins/vuetify.ts#L6-L22

色の設定と要素の関係:

- `main`: ヘッダー / プレイヤーのトグル
- `sub`: 再生中トラックの色
- `accent`: シークバー / 検索アイコン
- `background1`: 最背面の色
- `background2`: 背景色