### PR TITLE
曲一覧でクエリに大文字アルファベットが入ると正しく検索されない

### DIFF
--- a/src/models/track.ts
+++ b/src/models/track.ts
@@ -89,7 +89,7 @@ export class Track {
         channelName,
         this.tags.join('  '),
       ].join('  ').toLowerCase();
-      isMatch = isMatch && target.indexOf(keyword) >= 0;
+      isMatch = isMatch && target.indexOf(keyword.toLowerCase()) >= 0;
     }
     return isMatch;
   }


### PR DESCRIPTION
#9 の問題を解決

- クエリとターゲットの文字列をすべて小文字に変換して検索